### PR TITLE
Fix .gitignore to include /template_files/Manifest.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ docs/site/
 # It records a fixed state of all packages used by the project. As such, it should not be
 # committed for packages, but should be committed for applications that require a static
 # environment.
-Manifest.toml
+/Manifest.toml
 
 # AWS SAM files
 samconfig.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LambdaMaker"
 uuid = "8b137802-21d4-43b8-8610-b92ef2bbc330"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"

--- a/template_files/Manifest.toml
+++ b/template_files/Manifest.toml
@@ -1,0 +1,1 @@
+# This file is machine-generated - editing it directly is not advised


### PR DESCRIPTION
Modified the `.gitignore` to only exclude the root (this projects) `Manifest.toml` and not the one we actually want to copy over which is used when building the Docker image.