### PR TITLE
Use current directory for Docker Context when running SAM build

### DIFF
--- a/template_files/template.yml
+++ b/template_files/template.yml
@@ -12,7 +12,7 @@ Resources:
       Timeout: 60
     Metadata:
       Dockerfile: Dockerfile
-      DockerContext: ./template_files
+      DockerContext: .
       DockerTag: julia1.6-v1
 
 Outputs:


### PR DESCRIPTION
Originally when creating this package I was testing building SAM apps via the project itself, in this case I needed to set the `Docker Context` to the `./template_files` directory. However this was incorrect when looking at the actual use case for this package.

When you generate all the boilerplate code for making a Lambda function, the correct context you want to set for SAM build is actually `.`, as this is where the files actually exist.

Resolves: #9 